### PR TITLE
fix some issues included preflight OPTIONS 405 and add better code example in docs in STACAPI

### DIFF
--- a/docs/source/developers/stac.rst
+++ b/docs/source/developers/stac.rst
@@ -115,6 +115,28 @@ Landing Page
             response = HTTP.get("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/")
             data = JSON.parse(String(HTTP.body(response)))
 
+        .. code-tab:: c
+            :caption: C/C++
+
+            #include <stdio.h>
+            #include <curl/curl.h>
+
+            int main() {
+                CURL *curl;
+                CURLcode res;
+
+                curl = curl_easy_init();
+                if (curl) {
+                    char url[] = "https://www.freva.dkrz.de/api/freva-nextgen/stacapi/";
+
+                    curl_easy_setopt(curl, CURLOPT_URL, url);
+                    res = curl_easy_perform(curl);
+                    curl_easy_cleanup(curl);
+                }
+
+                return 0;
+            }
+
 ---
 
 .. _stacapi-conformance:
@@ -154,6 +176,59 @@ Conformance Classes
                 "https://api.stacspec.org/v1.0.0/item-search"
             ]
         }
+
+    Code examples
+    ~~~~~~~~~~~~~
+
+    .. tabs::
+
+        .. code-tab:: bash
+            :caption: Shell
+
+            curl -X GET https://www.freva.dkrz.de/api/freva-nextgen/stacapi/conformance
+
+        .. code-tab:: python
+            :caption: Python
+
+            import requests
+            response = requests.get("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/conformance")
+            data = response.json()
+
+        .. code-tab:: r
+            :caption: gnuR
+
+            library(httr)
+            response <- GET("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/conformance")
+            data <- jsonlite::fromJSON(content(response, as = "text", encoding = "utf-8"))
+
+        .. code-tab:: julia
+            :caption: Julia
+
+            using HTTP, JSON
+            response = HTTP.get("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/conformance")
+            data = JSON.parse(String(HTTP.body(response)))
+
+        .. code-tab:: c
+            :caption: C/C++
+
+            #include <stdio.h>
+            #include <curl/curl.h>
+
+            int main() {
+                CURL *curl;
+                CURLcode res;
+
+                curl = curl_easy_init();
+                if (curl) {
+                    char url[] = "https://www.freva.dkrz.de/api/freva-nextgen/stacapi/conformance";
+
+                    curl_easy_setopt(curl, CURLOPT_URL, url);
+                    res = curl_easy_perform(curl);
+                    curl_easy_cleanup(curl);
+                }
+
+                return 0;
+            }
 
 ---
 
@@ -230,6 +305,44 @@ Collections
             response = requests.get("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections")
             collections = response.json()["collections"]
 
+        .. code-tab:: r
+            :caption: gnuR
+
+            library(httr)
+            response <- GET("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections")
+            data <- jsonlite::fromJSON(content(response, as = "text", encoding = "utf-8"))
+            collections <- data$collections
+
+        .. code-tab:: julia
+            :caption: Julia
+
+            using HTTP, JSON
+            response = HTTP.get("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections")
+            data = JSON.parse(String(HTTP.body(response)))
+            collections = data["collections"]
+
+        .. code-tab:: c
+            :caption: C/C++
+
+            #include <stdio.h>
+            #include <curl/curl.h>
+
+            int main() {
+                CURL *curl;
+                CURLcode res;
+
+                curl = curl_easy_init();
+                if (curl) {
+                    char url[] = "https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections";
+
+                    curl_easy_setopt(curl, CURLOPT_URL, url);
+                    res = curl_easy_perform(curl);
+                    curl_easy_cleanup(curl);
+                }
+
+                return 0;
+            }
+
 ---
 
 .. _stacapi-collection-details:
@@ -287,6 +400,59 @@ Get Collection
             ],
             "keywords": ["observations", "climate", "analysis", "freva"]
         }
+
+    Code examples
+    ~~~~~~~~~~~~~
+
+    .. tabs::
+
+        .. code-tab:: bash
+            :caption: Shell
+
+            curl -X GET https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations
+
+        .. code-tab:: python
+            :caption: Python
+
+            import requests
+            response = requests.get("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations")
+            collection = response.json()
+
+        .. code-tab:: r
+            :caption: gnuR
+
+            library(httr)
+            response <- GET("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations")
+            collection <- jsonlite::fromJSON(content(response, as = "text", encoding = "utf-8"))
+
+        .. code-tab:: julia
+            :caption: Julia
+
+            using HTTP, JSON
+            response = HTTP.get("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations")
+            collection = JSON.parse(String(HTTP.body(response)))
+
+        .. code-tab:: c
+            :caption: C/C++
+
+            #include <stdio.h>
+            #include <curl/curl.h>
+
+            int main() {
+                CURL *curl;
+                CURLcode res;
+
+                curl = curl_easy_init();
+                if (curl) {
+                    char url[] = "https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations";
+
+                    curl_easy_setopt(curl, CURLOPT_URL, url);
+                    res = curl_easy_perform(curl);
+                    curl_easy_cleanup(curl);
+                }
+
+                return 0;
+            }
 
 ---
 
@@ -407,6 +573,42 @@ Get Collection Items
             )
             data <- jsonlite::fromJSON(content(response, as = "text", encoding = "utf-8"))
 
+        .. code-tab:: julia
+            :caption: Julia
+
+            using HTTP, JSON
+            response = HTTP.get(
+                "https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations/items",
+                query = Dict(
+                    "limit" => 10,
+                    "datetime" => "2016-01-01/2016-12-31",
+                    "bbox" => "-10,40,10,60"
+                )
+            )
+            data = JSON.parse(String(HTTP.body(response)))
+
+        .. code-tab:: c
+            :caption: C/C++
+
+            #include <stdio.h>
+            #include <curl/curl.h>
+
+            int main() {
+                CURL *curl;
+                CURLcode res;
+
+                curl = curl_easy_init();
+                if (curl) {
+                    char url[] = "https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations/items?limit=10&datetime=2016-01-01/2016-12-31&bbox=-10,40,10,60";
+
+                    curl_easy_setopt(curl, CURLOPT_URL, url);
+                    res = curl_easy_perform(curl);
+                    curl_easy_cleanup(curl);
+                }
+
+                return 0;
+            }
+
 ---
 
 .. _stacapi-collection-item-details:
@@ -470,6 +672,59 @@ Get Collection Item Details
                 }
             }
         }
+
+    Code examples
+    ~~~~~~~~~~~~~
+
+    .. tabs::
+
+        .. code-tab:: bash
+            :caption: Shell
+
+            curl -X GET https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations/items/1834103571652542466
+
+        .. code-tab:: python
+            :caption: Python
+
+            import requests
+            response = requests.get("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations/items/1834103571652542466")
+            item = response.json()
+
+        .. code-tab:: r
+            :caption: gnuR
+
+            library(httr)
+            response <- GET("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations/items/1834103571652542466")
+            item <- jsonlite::fromJSON(content(response, as = "text", encoding = "utf-8"))
+
+        .. code-tab:: julia
+            :caption: Julia
+
+            using HTTP, JSON
+            response = HTTP.get("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations/items/1834103571652542466")
+            item = JSON.parse(String(HTTP.body(response)))
+
+        .. code-tab:: c
+            :caption: C/C++
+
+            #include <stdio.h>
+            #include <curl/curl.h>
+
+            int main() {
+                CURL *curl;
+                CURLcode res;
+
+                curl = curl_easy_init();
+                if (curl) {
+                    char url[] = "https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations/items/1834103571652542466";
+
+                    curl_easy_setopt(curl, CURLOPT_URL, url);
+                    res = curl_easy_perform(curl);
+                    curl_easy_cleanup(curl);
+                }
+
+                return 0;
+            }
 
 ---
 
@@ -584,6 +839,43 @@ Search (GET)
             )
             data <- jsonlite::fromJSON(content(response, as = "text", encoding = "utf-8"))
 
+        .. code-tab:: julia
+            :caption: Julia
+
+            using HTTP, JSON
+            response = HTTP.get(
+                "https://www.freva.dkrz.de/api/freva-nextgen/stacapi/search",
+                query = Dict(
+                    "collections" => "observations",
+                    "q" => "temperature",
+                    "bbox" => "-180,-90,180,90",
+                    "limit" => 10
+                )
+            )
+            data = JSON.parse(String(HTTP.body(response)))
+
+        .. code-tab:: c
+            :caption: C/C++
+
+            #include <stdio.h>
+            #include <curl/curl.h>
+
+            int main() {
+                CURL *curl;
+                CURLcode res;
+
+                curl = curl_easy_init();
+                if (curl) {
+                    char url[] = "https://www.freva.dkrz.de/api/freva-nextgen/stacapi/search?collections=observations&q=temperature&bbox=-180,-90,180,90&limit=10";
+
+                    curl_easy_setopt(curl, CURLOPT_URL, url);
+                    res = curl_easy_perform(curl);
+                    curl_easy_cleanup(curl);
+                }
+
+                return 0;
+            }
+
 ---
 
 .. _stacapi-search-post:
@@ -667,6 +959,78 @@ Search (POST)
             )
             results = response.json()
 
+        .. code-tab:: r
+            :caption: gnuR
+
+            library(httr)
+            response <- POST(
+                "https://www.freva.dkrz.de/api/freva-nextgen/stacapi/search",
+                body = list(
+                    collections = list("observations"),
+                    q = list("temperature"),
+                    bbox = list(-180, -90, 180, 90),
+                    limit = 10
+                ),
+                encode = "json"
+            )
+            data <- jsonlite::fromJSON(content(response, as = "text", encoding = "utf-8"))
+
+        .. code-tab:: julia
+            :caption: Julia
+
+            using HTTP, JSON
+            response = HTTP.post(
+                "https://www.freva.dkrz.de/api/freva-nextgen/stacapi/search",
+                headers = Dict("Content-Type" => "application/json"),
+                body = JSON.json(Dict(
+                    "collections" => ["observations"],
+                    "q" => ["temperature"],
+                    "bbox" => [-180, -90, 180, 90],
+                    "limit" => 10
+                ))
+            )
+            data = JSON.parse(String(HTTP.body(response)))
+
+        .. code-tab:: c
+            :caption: C/C++
+
+            #include <stdio.h>
+            #include <curl/curl.h>
+
+            int main() {
+                CURL *curl;
+                CURLcode res;
+
+                const char *url = "https://www.freva.dkrz.de/api/freva-nextgen/stacapi/search";
+                const char *json_data = "{"
+                    "\"collections\": [\"observations\"],"
+                    "\"q\": [\"temperature\"],"
+                    "\"bbox\": [-180, -90, 180, 90],"
+                    "\"limit\": 10"
+                "}";
+
+                curl = curl_easy_init();
+                if (curl) {
+                    struct curl_slist *headers = NULL;
+                    headers = curl_slist_append(headers, "Content-Type: application/json");
+
+                    curl_easy_setopt(curl, CURLOPT_URL, url);
+                    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+                    curl_easy_setopt(curl, CURLOPT_POST, 1L);
+                    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, json_data);
+
+                    res = curl_easy_perform(curl);
+                    if (res != CURLE_OK) {
+                        fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+                    }
+
+                    curl_slist_free_all(headers);
+                    curl_easy_cleanup(curl);
+                }
+
+                return 0;
+            }
+
 ---
 
 .. _stacapi-queryables:
@@ -721,6 +1085,59 @@ Queryables
             }
         }
 
+    Code examples
+    ~~~~~~~~~~~~~
+
+    .. tabs::
+
+        .. code-tab:: bash
+            :caption: Shell
+
+            curl -X GET https://www.freva.dkrz.de/api/freva-nextgen/stacapi/queryables
+
+        .. code-tab:: python
+            :caption: Python
+
+            import requests
+            response = requests.get("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/queryables")
+            queryables = response.json()
+
+        .. code-tab:: r
+            :caption: gnuR
+
+            library(httr)
+            response <- GET("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/queryables")
+            queryables <- jsonlite::fromJSON(content(response, as = "text", encoding = "utf-8"))
+
+        .. code-tab:: julia
+            :caption: Julia
+
+            using HTTP, JSON
+            response = HTTP.get("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/queryables")
+            queryables = JSON.parse(String(HTTP.body(response)))
+
+        .. code-tab:: c
+            :caption: C/C++
+
+            #include <stdio.h>
+            #include <curl/curl.h>
+
+            int main() {
+                CURL *curl;
+                CURLcode res;
+
+                curl = curl_easy_init();
+                if (curl) {
+                    char url[] = "https://www.freva.dkrz.de/api/freva-nextgen/stacapi/queryables";
+
+                    curl_easy_setopt(curl, CURLOPT_URL, url);
+                    res = curl_easy_perform(curl);
+                    curl_easy_cleanup(curl);
+                }
+
+                return 0;
+            }
+
 ---
 
 .. _stacapi-collection-queryables:
@@ -749,6 +1166,58 @@ Collection Queryables
         GET /api/freva-nextgen/stacapi/collections/observations/queryables HTTP/1.1
         Host: www.freva.dkrz.de
 
+    Code examples
+    ~~~~~~~~~~~~~
+
+    .. tabs::
+
+        .. code-tab:: bash
+            :caption: Shell
+
+            curl -X GET https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations/queryables
+
+        .. code-tab:: python
+            :caption: Python
+
+            import requests
+            response = requests.get("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations/queryables")
+            queryables = response.json()
+
+        .. code-tab:: r
+            :caption: gnuR
+
+            library(httr)
+            response <- GET("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations/queryables")
+            queryables <- jsonlite::fromJSON(content(response, as = "text", encoding = "utf-8"))
+
+        .. code-tab:: julia
+            :caption: Julia
+
+            using HTTP, JSON
+            response = HTTP.get("https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations/queryables")
+            queryables = JSON.parse(String(HTTP.body(response)))
+
+        .. code-tab:: c
+            :caption: C/C++
+
+            #include <stdio.h>
+            #include <curl/curl.h>
+
+            int main() {
+                CURL *curl;
+                CURLcode res;
+
+                curl = curl_easy_init();
+                if (curl) {
+                    char url[] = "https://www.freva.dkrz.de/api/freva-nextgen/stacapi/collections/observations/queryables";
+
+                    curl_easy_setopt(curl, CURLOPT_URL, url);
+                    res = curl_easy_perform(curl);
+                    curl_easy_cleanup(curl);
+                }
+
+                return 0;
+            }
 
 
 ---
@@ -763,26 +1232,71 @@ The Freva STAC-API is fully compatible with STAC-compliant tools and libraries. 
 - **R**: `rstac`
 - **JavaScript**: `@stac/client`
 
-Python Example with `pystac-client`
---------------------------------------
+Integration Examples
+-------------------
 
-.. code-tab:: python
+.. tabs::
 
-    from pystac_client import Client
+    .. code-tab:: python
+        :caption: Python with pystac-client
 
-    # Connect to the STAC API
-    catalog = Client.open("https://www.freva.dkrz.de/api/freva-nextgen/stacapi")
+        from pystac_client import Client
 
-    # Search for items
-    search = catalog.search(
-        collections=["observations"],
-        datetime="2020-01-01/2020-12-31",
-        bbox=[-10, 40, 10, 60]
-    )
+        # Connect to the STAC API
+        catalog = Client.open("https://www.freva.dkrz.de/api/freva-nextgen/stacapi")
 
-    # Get items
-    items = list(search.get_items())
-    print(f"Found {len(items)} items")
+        # Search for items
+        search = catalog.search(
+            collections=["observations"],
+            datetime="2020-01-01/2020-12-31",
+            bbox=[-10, 40, 10, 60]
+        )
+
+        # Get items
+        items = list(search.get_items())
+        print(f"Found {len(items)} items")
+
+    .. code-tab:: r
+        :caption: R with rstac
+
+        library(rstac)
+
+        # Connect to the STAC API
+        catalog <- stac("https://www.freva.dkrz.de/api/freva-nextgen/stacapi")
+
+        # Search for items
+        search <- catalog %>%
+            stac_search(
+                collections = "observations",
+                datetime = "2020-01-01/2020-12-31",
+                bbox = c(-10, 40, 10, 60)
+            ) %>%
+            get_request()
+
+        # Get items
+        items <- search$features
+        cat("Found", length(items), "items\n")
+
+    .. code-tab:: javascript
+        :caption: JavaScript with @stac/client
+
+        import { STACApiClient } from '@stac/client';
+
+        // Connect to the STAC API
+        const client = new STACApiClient({
+            url: 'https://www.freva.dkrz.de/api/freva-nextgen/stacapi'
+        });
+
+        // Search for items
+        const search = await client.search({
+            collections: ['observations'],
+            datetime: '2020-01-01/2020-12-31',
+            bbox: [-10, 40, 10, 60]
+        });
+
+        // Get items
+        const items = await search.getItems();
+        console.log(`Found ${items.length} items`);
 
 ---
 
@@ -795,4 +1309,3 @@ Python Example with `pystac-client`
 
 .. important::
    Data transaction and ingestion into the Freva STAC-API is managed by administrators using the `data-crawler <https://freva.gitlab-pages.dkrz.de/metadata-crawler-source/docs/>`_ tool. This has nothing to do with the STAC API itself, which is primarily focused on data discovery and access.
-

--- a/docs/source/developers/stac.rst
+++ b/docs/source/developers/stac.rst
@@ -1229,10 +1229,8 @@ STAC-API Integration
 The Freva STAC-API is fully compatible with STAC-compliant tools and libraries. You can use popular tools like:
 
 - **Python**: `pystac-client`, `pystac`, `stackstac`
-- **R**: `rstac`
-- **JavaScript**: `@stac/client`
 
-Integration Examples
+Integration Example with Python
 -------------------
 
 .. tabs::
@@ -1242,61 +1240,19 @@ Integration Examples
 
         from pystac_client import Client
 
-        # Connect to the STAC API
+        # Connect to the Freva STAC API
         catalog = Client.open("https://www.freva.dkrz.de/api/freva-nextgen/stacapi")
 
         # Search for items
         search = catalog.search(
-            collections=["observations"],
-            datetime="2020-01-01/2020-12-31",
+            max_items=10,
+            collections=["cmip6"],
             bbox=[-10, 40, 10, 60]
         )
 
         # Get items
-        items = list(search.get_items())
+        items = list(search.items())
         print(f"Found {len(items)} items")
-
-    .. code-tab:: r
-        :caption: R with rstac
-
-        library(rstac)
-
-        # Connect to the STAC API
-        catalog <- stac("https://www.freva.dkrz.de/api/freva-nextgen/stacapi")
-
-        # Search for items
-        search <- catalog %>%
-            stac_search(
-                collections = "observations",
-                datetime = "2020-01-01/2020-12-31",
-                bbox = c(-10, 40, 10, 60)
-            ) %>%
-            get_request()
-
-        # Get items
-        items <- search$features
-        cat("Found", length(items), "items\n")
-
-    .. code-tab:: javascript
-        :caption: JavaScript with @stac/client
-
-        import { STACApiClient } from '@stac/client';
-
-        // Connect to the STAC API
-        const client = new STACApiClient({
-            url: 'https://www.freva.dkrz.de/api/freva-nextgen/stacapi'
-        });
-
-        // Search for items
-        const search = await client.search({
-            collections: ['observations'],
-            datetime: '2020-01-01/2020-12-31',
-            bbox: [-10, 40, 10, 60]
-        });
-
-        // Get items
-        const items = await search.getItems();
-        console.log(`Found ${items.length} items`);
 
 ---
 

--- a/freva-rest/src/freva_rest/stac_api/core.py
+++ b/freva-rest/src/freva_rest/stac_api/core.py
@@ -279,7 +279,7 @@ class STACAPI:
         # for constructing this. For time being we define them all as
         # constants, since we don't have any usecase for this yet.
         # TODO: We need to add assets to the collections
-
+        collection_id = collection_id.lower()
         collection_ids = await self.get_all_project_facets()
         if collection_id not in collection_ids:
             raise HTTPException(
@@ -437,7 +437,7 @@ class STACAPI:
         collection_id: str,
     ) -> Item:
         """Create a STAC item from the Solr doc."""
-
+        collection_id = collection_id.lower()
         id = result.get(self.uniq_key, "")
         zarr_desc = dedent(
             f"""
@@ -810,6 +810,7 @@ class STACAPI:
     ) -> AsyncGenerator[str, None]:
         """Get a all items of a specific collection."""
         base_params: Dict[str, Any] = {"limit": limit}
+        collection_id = collection_id.lower()
         if datetime:
             base_params["datetime"] = datetime
         if bbox:

--- a/freva-rest/src/freva_rest/stac_api/endpoints.py
+++ b/freva-rest/src/freva_rest/stac_api/endpoints.py
@@ -45,9 +45,16 @@ class STACCORSMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         if not request.url.path.startswith(self.stac_path_prefix):
             return await call_next(request)
+        if request.method == "OPTIONS":
+            headers = {
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+                "Access-Control-Allow-Headers": "*",
+            }
+            return Response(status_code=200, headers=headers)
         response = await call_next(request)
         response.headers["Access-Control-Allow-Origin"] = "*"
-        response.headers["Access-Control-Allow-Methods"] = "GET, POST"
+        response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
         response.headers["Access-Control-Allow-Headers"] = "*"
 
         return response

--- a/freva-rest/src/freva_rest/utils/stac_utils.py
+++ b/freva-rest/src/freva_rest/utils/stac_utils.py
@@ -1,7 +1,7 @@
 """ utilities for the STAC."""
 
 import re
-from datetime import datetime, MINYEAR, MAXYEAR
+from datetime import MAXYEAR, MINYEAR, datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from dateutil import parser

--- a/freva-rest/src/freva_rest/utils/stac_utils.py
+++ b/freva-rest/src/freva_rest/utils/stac_utils.py
@@ -1,10 +1,13 @@
 """ utilities for the STAC."""
 
-from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple, Union
 import re
+from datetime import datetime, MINYEAR, MAXYEAR
+from typing import Any, Dict, List, Optional, Tuple, Union
+
 from dateutil import parser
+
 YEAR_ONLY = re.compile(r"^\d{1,4}$")
+
 
 class Item:
     """ Item class which is compatible with pySTAC
@@ -129,13 +132,13 @@ def parse_datetime(time_str: str) -> Tuple[datetime, datetime]:
     try:
         if YEAR_ONLY.fullmatch(start_str) and YEAR_ONLY.fullmatch(end_str):
             sy, ey = int(start_str), int(end_str)
-            sy = max(datetime.MINYEAR, min(sy, datetime.MAXYEAR))
-            ey = max(datetime.MINYEAR, min(ey, datetime.MAXYEAR))
+            sy = max(MINYEAR, min(sy, MAXYEAR))
+            ey = max(MINYEAR, min(ey, MAXYEAR))
             start_dt = datetime(sy, 1, 1)
-            end_dt   = datetime(ey, 12, 31, 23, 59, 59)
+            end_dt = datetime(ey, 12, 31, 23, 59, 59)
         else:
             start_dt = parser.parse(start_str)
-            end_dt   = parser.parse(end_str)
+            end_dt = parser.parse(end_str)
     except Exception:
         start_dt, end_dt = datetime.min, datetime.max
 

--- a/tests/test_stacapi.py
+++ b/tests/test_stacapi.py
@@ -430,3 +430,17 @@ def test_stacapi_search_filter(test_server: str) -> None:
     # Invalid JSON
     res = requests.get(f"{test_server}/stacapi/search", params={"filter": "invalid_json", "limit": 1})
     assert res.status_code == 200 
+def test_cors_preflight_options(test_server: str) -> None:
+    """Preflight (OPTIONS) on STAC search must return 200 + CORS headers."""
+    resp = requests.options(
+        f"{test_server}/stacapi/search",
+        headers={
+            "Origin": "https://radiantearth.github.io",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "Content-Type",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == "*"
+    assert "POST" in resp.headers.get("access-control-allow-methods", "")
+    assert "*" in resp.headers.get("access-control-allow-headers", "")


### PR DESCRIPTION
There was an issue between our STAC-API search endpoints and only STAC-Browser front-end (as a client) which we forgot to fix it earlier. This change, updates the existing STACCORSMiddleware class on STAC-API endpoints, so that it now intercepts preflight OPTIONS requests and immediately returns HTTP 200 with the appropriate Access‑Control‑Allow-* headers for all endpoints, contains /api/freva‑nextgen/stacapi, before passing on any GET or POST search endpoint. As a result user doesn't get the `network error` when they search for the data.

Also there were some minor issues in the parsing_time function of STACAPI which is fixed now. 

Documentation has been a bit polished as well to make it more understandable on end-user side. 