### PR TITLE
fix stac-version schema.py

### DIFF
--- a/freva-rest/src/freva_rest/stac_api/schema.py
+++ b/freva-rest/src/freva_rest/stac_api/schema.py
@@ -4,7 +4,7 @@ from urllib.parse import parse_qs
 from fastapi import Query, Request
 from pydantic import BaseModel, Field
 
-STAC_VERSION = "1.1.0"
+STAC_VERSION = "1.0.0"
 
 CONFORMANCE_URLS = [
     "https://api.stacspec.org/v1.0.0/core",

--- a/tests/test_stacapi.py
+++ b/tests/test_stacapi.py
@@ -7,7 +7,7 @@ import requests
 def test_stacapi_basic(test_server: str) -> None:
     """Test the default stacapi functionality."""
     result_catalog = requests.get(f"{test_server}/stacapi/")
-    assert result_catalog.json()["stac_version"] == "1.1.0"
+    assert result_catalog.json()["stac_version"] == "1.0.0"
     assert result_catalog.json()["type"] == "Catalog"
 
     result_collections = requests.get(f"{test_server}/stacapi/collections")
@@ -17,7 +17,7 @@ def test_stacapi_basic(test_server: str) -> None:
     result_collection = requests.get(f"{test_server}/stacapi/collections/cmip6")
     assert result_collection.status_code == 200
     assert result_collection.json()["id"] == "cmip6"
-    assert result_collection.json()["stac_version"] == "1.1.0"
+    assert result_collection.json()["stac_version"] == "1.0.0"
     assert result_collection.json()["type"] == "Collection"
 
     result_items = requests.get(f"{test_server}/stacapi/collections/cmip6/items")

--- a/tests/test_stacapi.py
+++ b/tests/test_stacapi.py
@@ -17,7 +17,7 @@ def test_stacapi_basic(test_server: str) -> None:
     result_collection = requests.get(f"{test_server}/stacapi/collections/cmip6")
     assert result_collection.status_code == 200
     assert result_collection.json()["id"] == "cmip6"
-    assert result_collection.json()["stac_version"] == "1.0.0"
+    assert result_collection.json()["stac_version"] == "1.1.0"
     assert result_collection.json()["type"] == "Collection"
 
     result_items = requests.get(f"{test_server}/stacapi/collections/cmip6/items")


### PR DESCRIPTION
since STAC-API is designed based on the v1.0.0, changing the number of version was forgotten that is fixed now. if we don't change the version, there would be a problem with stac-validator that then based on the catalog schema, it considers the catalog as a invalid.