### PR TITLE
add split method to avoid adding new fsspec dependency

### DIFF
--- a/freva-rest/src/freva_rest/utils/stac_utils.py
+++ b/freva-rest/src/freva_rest/utils/stac_utils.py
@@ -5,10 +5,17 @@ from datetime import MAXYEAR, MINYEAR, datetime
 from textwrap import dedent
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import fsspec.core
 from dateutil import parser
 
 YEAR_ONLY = re.compile(r"^\d{1,4}$")
+
+
+def split_protocol(path: str) -> Tuple[Optional[str], str]:
+    """Split protocol from path."""
+    if "://" in path:
+        protocol, rest = path.split("://", 1)
+        return protocol, rest
+    return None, path
 
 
 class Item:
@@ -185,7 +192,7 @@ def generate_local_access_desc(file_id: str) -> str:
     str
         Formatted description with appropriate access code
     """
-    protocol, _ = fsspec.core.split_protocol(file_id)
+    protocol, _ = split_protocol(file_id)
     is_remote = protocol in ("s3", "gs", "gcs", "azure", "abfs", "http", "https")
     is_zarr = file_id.endswith(".zarr")
 


### PR DESCRIPTION
 `fsspec` has been added to the stac_utils but we forgot to add it to the freva-rest deps and as a result we got a broken image. Also the most strange part, tests didn't give us a heads up about this issue!
I would merge immediately after green ci to turn the production machines back to the life again
FYI @antarcticrainforest 