### PR TITLE
fix(docs): link to freva legacy

### DIFF
--- a/docs/source/auth/auth-lib.rst
+++ b/docs/source/auth/auth-lib.rst
@@ -6,8 +6,7 @@ Authentication using the freva-client library
 The freva-client python library offers a very simple interface to interact
 with the authentication system.
 
-.. automodule:: freva_client
-   :members: authenticate
+.. autofunction:: freva_client.authenticate
 
 .. _auth_cli:
 
@@ -28,19 +27,30 @@ sub command of the command line interface
    res = run(["freva-client", "auth", "--help"], check=True, stdout=PIPE, stderr=PIPE)
    print(res.stdout.decode())
 
-You can create a token using your username and password, but for security reasons
-your password cannot be passed as a command-line argument.
-Currently, a new token can only be created *from scratch* via the website of your host
-instance.
-Once logged in, click the **Token button** to generate a token, then copy, paste,
-or download it.
+You can create a token using your user name and password. 
 
-Store your token securely in a file and use it as refresh token to create new tokens:
+In the process of token generation, you would want to store your token data *securely*
+in a file, and use it as a refresh token to create new ones, eventually:
 
 .. code:: console
 
-    freva-client auth --token-file ~/.my_old_token.json > ~/.my_new_token.json
-    chmod 600 ~/.my_new_token.json
+    freva-client auth  > ~/.mytoken.json
+    chmod 600  ~/.mytoken.json
+
+
+For security reasons you cannot pass your password as an argument to the command line
+interface. This means that, in a *non-interactive* session such as a batch job, you
+will have two options:
+
+1. Either use the valid token with ``--token-file <my_token_file>``.
+2. Or, if you want to create a new one, you will *only* be able to do it with help
+   of an already pre-existing valid refresh token.
+
+   .. code:: console
+
+       freva-client auth --token-file ~/.my_old_token.json > ~/.my_new_token.json
+       chmod 600 ~/.my_new_token.json
+
 
 .. warning::
 

--- a/docs/source/auth/auth-lib.rst
+++ b/docs/source/auth/auth-lib.rst
@@ -28,26 +28,19 @@ sub command of the command line interface
    res = run(["freva-client", "auth", "--help"], check=True, stdout=PIPE, stderr=PIPE)
    print(res.stdout.decode())
 
-You can create a token using your user name and password. For security reasons
-you can not pass your password as an argument to the command line interface.
-This means that you can only create a new token with help of a valid refresh
-token in a non-interactive session. Such as a batch job.
+You can create a token using your username and password, but for security reasons
+your password cannot be passed as a command-line argument.
+Currently, a new token can only be created *from scratch* via the website of your host
+instance.
+Once logged in, click the **Token button** to generate a token, then copy, paste,
+or download it.
 
-Therefore you want to store your token data securely in a file, and use the
-refresh token to create new tokens:
-
-.. code:: console
-
-    freva-client auth  > ~/.mytoken.json
-    chmod 600 ~/.mytoken.json
-
-Later you can use the `jq json command line parser <https://jqlang.github.io/jq/>`_
-to read the refresh token from and use it to create new access tokens.
+Store your token securely in a file and use it as refresh token to create new tokens:
 
 .. code:: console
 
-    freva-client auth --token-file ~/.mytoken.json > ~/.mytoken.json
-
+    freva-client auth --token-file ~/.my_old_token.json > ~/.my_new_token.json
+    chmod 600 ~/.my_new_token.json
 
 .. warning::
 

--- a/docs/source/databrowser/cli.rst
+++ b/docs/source/databrowser/cli.rst
@@ -347,7 +347,7 @@ Adding and Deleting User Data
 
 You can manage your personal datasets within the databrowser by adding or deleting user-specific data. This functionality allows you to include your own data files into the databrowser, making them accessible for analysis and retrieval alongside other datasets.
 
-Before using the `user-data` commands, you need to create an access token and authenticate with the system. Please refer to the :ref:`auth` chapter for more details on token creation and authentication.
+Before using the `user-data` commands, you need to create an access token and authenticate with the system. Please refer to the :ref:`auth` chapter for more details on token creation and authentication.  
 
 Adding User Data
 ~~~~~~~~~~~~~~~~
@@ -356,14 +356,13 @@ To add your data to the databrowser, use the `user-data add` command. You'll nee
 
 .. code:: console
 
-    token=$(freva-client auth -u janedoe | jq -r .access_token)
     freva-client databrowser user-data add \
         --path freva-rest/src/freva_rest/databrowser_api/mock/ \
         --facet project=cordex \
         --facet experiment=rcp85 \
         --facet model=mpi-m-mpi-esm-lr-clmcom-cclm4-8-17-v1 \
         --facet variable=tas \
-        --access-token $token
+        --token-file ~/.access_token
 
 
 This command adds the specified data files to the databrowser and tags them with the provided metadata. These search filters help in indexing and searching your data within the system.
@@ -375,10 +374,9 @@ If you need to remove your data from the databrowser, use the `user-data delete`
 
 .. code:: console
 
-    token=$(freva-client auth -u janedoe | jq -r .access_token)
     freva-client databrowser user-data delete \
         --search-key project=cordex \
         --search-key experiment=rcp85 \
-        --access-token $token
+        --token-file ~/.access_token
 
 This command deletes all data entries that match the specified search keys from the databrowser.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,7 +41,7 @@ This documentation describes the *freva-client* library, its
 command line interface (cli) and the REST API. The *freva-client* library
 described in this documentation only support searching for data. If you
 need to apply data analysis plugins, please visit the
-`official documentation <https://freva-org.github.io/freva>`_
+`official documentation <https://freva-org.github.io/freva-legacy>`_
 
 .. _install+configure:
 

--- a/freva-client/src/freva_client/__init__.py
+++ b/freva-client/src/freva_client/__init__.py
@@ -12,6 +12,7 @@ science community. With help of Freva researchers can:
 The code described here is currently in testing phase. The client and server
 library described in the documentation only support searching for data. If you
 need to apply data analysis plugins, please visit the
+official documentation: https://freva-org.github.io/freva-legacy
 """
 
 from .auth import authenticate

--- a/freva-client/src/freva_client/auth.py
+++ b/freva-client/src/freva_client/auth.py
@@ -294,7 +294,7 @@ def authenticate(
 
     Parameters
     ----------
-    refresh_token: str, optional
+    token_file: str, optional
         Instead of setting a password, you can set a refresh token to refresh
         the access token. This is recommended for non-interactive environments.
     host: str, optional
@@ -308,15 +308,11 @@ def authenticate(
 
     Examples
     --------
-    Interactive authentication:
+    Currently, a new token can only be created *from scratch* via the website of
+    your host instance. Once logged in, click the **Token button** to generate a
+    refresh token, then copy, paste, or download it.
 
-    .. code-block:: python
-
-        from freva_client import authenticate
-        token = authenticate()
-        print(token)
-
-    Batch mode authentication with a refresh token:
+    Authentication with a refresh token:
 
     .. code-block:: python
 

--- a/freva-client/src/freva_client/auth.py
+++ b/freva-client/src/freva_client/auth.py
@@ -308,11 +308,15 @@ def authenticate(
 
     Examples
     --------
-    Currently, a new token can only be created *from scratch* via the website of
-    your host instance. Once logged in, click the **Token button** to generate a
-    refresh token, then copy, paste, or download it.
+    Interactive authentication:
 
-    Authentication with a refresh token:
+    .. code-block:: python
+
+        from freva_client import authenticate
+        token = authenticate()
+        print(token)
+
+    Batch mode authentication with a refresh token:
 
     .. code-block:: python
 

--- a/freva-data-portal-worker/src/data_portal_worker/load_data.py
+++ b/freva-data-portal-worker/src/data_portal_worker/load_data.py
@@ -49,6 +49,20 @@ RedisKw = TypedDict(
         "ssl_key": str,
     },
 )
+RedisConnectionDict = TypedDict(
+    "RedisConnectionDict",
+    {
+        "host": str,
+        "port": int,
+        "db": int,
+        "username": Optional[str],
+        "password": Optional[str],
+        "ssl": bool,
+        "ssl_certfile": Optional[str],
+        "ssl_keyfile": Optional[str],
+        "ssl_ca_certs": Optional[str],
+    },
+)
 
 
 class RedisCacheFactory(redis.Redis):
@@ -61,7 +75,7 @@ class RedisCacheFactory(redis.Redis):
             .partition(":")
         )
         port_i = int(port or "6379")
-        conn = {
+        conn: RedisConnectionDict = {
             "host": host,
             "port": port_i,
             "db": db,
@@ -70,8 +84,8 @@ class RedisCacheFactory(redis.Redis):
             "ssl_certfile": os.getenv("API_REDIS_SSL_CERTFILE") or None,
             "ssl_keyfile": os.getenv("API_REDIS_SSL_KEYFILE") or None,
             "ssl_ca_certs": os.getenv("API_REDIS_SSL_CERTFILE") or None,
+            "ssl": os.getenv("API_REDIS_SSL_CERTFILE") is not None,
         }
-        conn["ssl"] = conn["ssl_certfile"] is not None
         data_logger.info("Creating redis connection with args: %s", conn)
         super().__init__(
             host=conn["host"],


### PR DESCRIPTION
currently (since the project move and freva repo renaming) there is no easy way to access old freva documentation as the only direct reference is this one link. 

