### PR TITLE
Give users the choice to set the login timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 ## [v2508.1.0]
 ### Added
- - Login timout option for doing the login.
+ - Login timeout option for doing the login.
  - Display better information on how to use port forwarding.
 
 ## [v2507.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [v2508.1.0]
+### Added
+ - Login timout option for doing the login.
+ - Display better information on how to use port forwarding.
+
 ## [v2507.0.0]
 ### Changed
  - Internal changes.

--- a/freva-client/src/freva_client/__init__.py
+++ b/freva-client/src/freva_client/__init__.py
@@ -17,5 +17,5 @@ need to apply data analysis plugins, please visit the
 from .auth import authenticate
 from .query import databrowser
 
-__version__ = "2508.0.0"
+__version__ = "2508.1.0"
 __all__ = ["authenticate", "databrowser", "__version__"]

--- a/freva-client/src/freva_client/auth.py
+++ b/freva-client/src/freva_client/auth.py
@@ -226,9 +226,7 @@ class Auth:
         return self._auth_token
 
     def _refresh(
-        self,
-        url: str,
-        refresh_token: str,
+        self, url: str, refresh_token: str, timeout: Optional[int] = 30
     ) -> Token:
         """Refresh the access_token with a refresh token."""
         try:
@@ -238,7 +236,7 @@ class Auth:
             )
         except (AuthError, KeyError) as error:
             logger.warning("Failed to refresh token: %s", error)
-            return self._login(url)
+            return self._login(url, _timeout=timeout)
 
     def authenticate(
         self,
@@ -262,7 +260,9 @@ class Auth:
             return self._auth_token
         try:
             if strategy == "refresh_token" and token:
-                return self._refresh(cfg.auth_url, token["refresh_token"])
+                return self._refresh(
+                    cfg.auth_url, token["refresh_token"], timeout=timeout
+                )
             if strategy == "browser_auth":
                 return self._login(cfg.auth_url, force=force, _timeout=timeout)
         except AuthError as error:

--- a/freva-client/src/freva_client/auth.py
+++ b/freva-client/src/freva_client/auth.py
@@ -113,7 +113,7 @@ class Auth:
         self,
         auth_url: str,
         force: bool = False,
-        _timeout: int = 30,
+        _timeout: Optional[int] = 30,
     ) -> Token:
         login_endpoint = f"{auth_url}/login"
         token_endpoint = f"{auth_url}/token"
@@ -142,7 +142,7 @@ class Auth:
         try:
             wait_for_port("localhost", port)
             webbrowser.open(login_url)
-            success = event.wait(timeout=_timeout)
+            success = event.wait(timeout=_timeout or None)
             if not success:
                 raise TimeoutError(
                     f"Login did not complete within {_timeout} seconds. "
@@ -243,6 +243,7 @@ class Auth:
         config: Optional[Config] = None,
         *,
         force: bool = False,
+        timeout: Optional[int] = 30,
         _cli: bool = False,
     ) -> Token:
         """Authenticate the user to the host."""
@@ -260,7 +261,7 @@ class Auth:
             if strategy == "refresh_token" and token:
                 return self._refresh(cfg.auth_url, token["refresh_token"])
             if strategy == "browser_auth":
-                return self._login(cfg.auth_url, force=force)
+                return self._login(cfg.auth_url, force=force, _timeout=timeout)
         except AuthError as error:
             reason = str(error)
 
@@ -287,6 +288,7 @@ def authenticate(
     token_file: Optional[Union[Path, str]] = None,
     host: Optional[str] = None,
     force: bool = False,
+    timeout: Optional[int] = 30,
 ) -> Token:
     """Authenticate to the host.
 
@@ -301,6 +303,8 @@ def authenticate(
         The hostname of the REST server.
     force: bool, default: False
         Force token recreation, even if current token is still valid.
+    timeout: int, default: 30
+        Set the timeout, None for indefinate.
 
     Returns
     -------
@@ -313,7 +317,7 @@ def authenticate(
     .. code-block:: python
 
         from freva_client import authenticate
-        token = authenticate()
+        token = authenticate(timeout=120)
         print(token)
 
     Batch mode authentication with a refresh token:
@@ -327,4 +331,5 @@ def authenticate(
     return auth.authenticate(
         host=host,
         force=force,
+        timeout=timeout,
     )

--- a/freva-client/src/freva_client/auth.py
+++ b/freva-client/src/freva_client/auth.py
@@ -5,6 +5,7 @@ import json
 import socket
 import urllib.parse
 import webbrowser
+from getpass import getuser
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from threading import Event, Lock, Thread
@@ -129,11 +130,13 @@ class Auth:
         logger.info("Opening browser for login:\n%s", login_url)
         logger.info(
             "If you are using this on a remote host, you might need to "
-            "forward port %d:\n"
-            "    ssh -L %d:localhost:%d user@remotehost",
+            "increase the login timeout and forward port %d:\n"
+            "    ssh -L %d:localhost:%d %s@%s",
             port,
             port,
             port,
+            getuser(),
+            socket.gethostname(),
         )
         event = Event()
         server = start_local_server(port, event)

--- a/freva-client/src/freva_client/cli/auth_cli.py
+++ b/freva-client/src/freva_client/cli/auth_cli.py
@@ -44,6 +44,11 @@ def authenticate_cli(
         "-f",
         help="Force token recreation, even if current token is still valid.",
     ),
+    timeout: int = typer.Option(
+        30,
+        "--timeout",
+        help="Set the timeout for login in secdonds, 0 for indefinate",
+    ),
     verbose: int = typer.Option(0, "-v", help="Increase verbosity", count=True),
     version: Optional[bool] = typer.Option(
         False,
@@ -59,5 +64,6 @@ def authenticate_cli(
         host=host,
         force=force,
         _cli=True,
+        timeout=timeout,
     )
     print(json.dumps(token, indent=3))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -114,7 +114,7 @@ def test_authenticate_with_refresh_token_failed(
     """Test authentication using a refresh token."""
     token = deepcopy(auth_instance._auth_token)
 
-    def mock_login(url: str, port: int = 0) -> None:
+    def mock_login(url: str, port: int = 0, _timeout: int = 30) -> None:
         raise AuthError("foo")
 
     try:


### PR DESCRIPTION
With this users can choose the login time. When port forwarding is needed or other things like token challenges are involved in the login process 30 secs of timeout are too little. With this users can increase the timeout or even set it to wait forever.

On top of the information displayed on who to do port forwarding is improved.

Thanks for quick review @mo-dkrz  