### PR TITLE
Adding default flavour for client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,5 +136,5 @@ dev-env/mongodb
 dev-env/certs
 *keycloakdb.lock.db
 *keycloakdb.*
-stac-catalog-*
+stac-catalog*
 .DS_Store

--- a/docs/source/databrowser/cli.rst
+++ b/docs/source/databrowser/cli.rst
@@ -421,7 +421,12 @@ To see all custom flavours available to you, use the `flavour list` command:
 
     freva-client databrowser flavour list
 
-This will display both personal flavours you've created and ``global`` flavours available to all users. You can also output the results in JSON format:
+.. note::
+    The `flavour list` command does not require authentication and will show global flavours available to all users.
+
+This will display both personal flavours you've created and ``global`` flavours available to all users.
+
+You can also output the results in JSON format:
 
 .. code:: console
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -112,6 +112,14 @@ on Linux):
     ## for example freva.example.org:7777
     # host = ""
 
+    ##
+    ## The default flavour (DRS standard) for the databrowser to use when accessing freva.
+    ## Options: freva, cmip5, cmip6, cordex, user, or custom gloabl flavours
+    ## that is visible to all users
+    ## If it has not been defined, the default is `freva``
+    # default_flavour = ""
+
+
 To permanently set or override the freva server host name you have to set
 the ``host`` variable in that file. In most cases this variable can be
 set to the url of the freva web site you are using, for example

--- a/freva-client/assets/share/freva/freva.toml
+++ b/freva-client/assets/share/freva/freva.toml
@@ -17,3 +17,8 @@
 ## You can set a port by separating <hostname:port>
 ## for example freva.example.org:7777
 # host = ""
+
+##
+## The default flavour to use when accessing freva. You can simply list
+## the flavours you want to use and choose one as default.
+# default_flavour = "cmip6"

--- a/freva-client/src/freva_client/query.py
+++ b/freva-client/src/freva_client/query.py
@@ -28,7 +28,12 @@ from rich import print as pprint
 
 from .auth import Auth
 from .utils import logger
-from .utils.auth_utils import Token, choose_token_strategy, load_token
+from .utils.auth_utils import (
+    Token,
+    choose_token_strategy,
+    load_token,
+    requires_authentication,
+)
 from .utils.databrowser_utils import Config, UserDataHandler
 
 __all__ = ["databrowser"]
@@ -225,7 +230,7 @@ class databrowser:
         self,
         *facets: str,
         uniq_key: Literal["file", "uri"] = "file",
-        flavour: str = "freva",
+        flavour: Optional[str] = None,
         time: Optional[str] = None,
         host: Optional[str] = None,
         time_select: Literal["flexible", "strict", "file"] = "flexible",
@@ -239,7 +244,7 @@ class databrowser:
         self._auth = Auth()
         self._fail_on_error = fail_on_error
         self._cfg = Config(host, uniq_key=uniq_key, flavour=flavour)
-        self._flavour = flavour
+        self._flavour = self._cfg.flavour
         self._stream_zarr = stream_zarr
         self.builtin_flavours = {"freva", "cmip6", "cmip5", "cordex", "user"}
         facet_search: Dict[str, List[str]] = defaultdict(list)
@@ -288,12 +293,10 @@ class databrowser:
 
     def __iter__(self) -> Iterator[str]:
         query_url = self._cfg.search_url
-        headers = {}
         if self._stream_zarr:
             query_url = self._cfg.zarr_loader_url
-            token = self._auth.authenticate(config=self._cfg)
-            headers = {"Authorization": f"Bearer {token['access_token']}"}
-        result = self._request("GET", query_url, headers=headers, stream=True)
+
+        result = self._request("GET", query_url, stream=True)
         if result is not None:
             try:
                 for res in result.iter_lines():
@@ -367,11 +370,7 @@ class databrowser:
         kwargs: Dict[str, Any] = {"stream": True}
         url = self._cfg.intake_url
         if self._stream_zarr:
-            token = self._auth.authenticate(config=self._cfg)
             url = self._cfg.zarr_loader_url
-            kwargs["headers"] = {
-                "Authorization": f"Bearer {token['access_token']}"
-            }
             kwargs["params"] = {"catalogue-type": "intake"}
         result = self._request("GET", url, **kwargs)
         if result is None:
@@ -538,7 +537,7 @@ class databrowser:
     def count_values(
         cls,
         *facets: str,
-        flavour: str = "freva",
+        flavour: Optional[str] = None,
         time: Optional[str] = None,
         host: Optional[str] = None,
         time_select: Literal["flexible", "strict", "file"] = "flexible",
@@ -693,7 +692,7 @@ class databrowser:
     def metadata_search(
         cls,
         *facets: str,
-        flavour: str = "freva",
+        flavour: Optional[str] = None,
         time: Optional[str] = None,
         host: Optional[str] = None,
         time_select: Literal["flexible", "strict", "file"] = "flexible",
@@ -1211,14 +1210,16 @@ class databrowser:
         kwargs.setdefault("headers", {})
 
         if (
-            self._flavour not in self.builtin_flavours
+            requires_authentication(
+                self._flavour,
+                self._stream_zarr,
+                self._cfg.databrowser_url
+            )
             and "Authorization" not in kwargs["headers"]
         ):
-            try:
-                token = self._auth.authenticate(config=self._cfg)
-                kwargs["headers"]["Authorization"] = f"Bearer {token['access_token']}"
-            except Exception:
-                pass
+            token = self._auth.authenticate(config=self._cfg)
+            kwargs["headers"]["Authorization"] = f"Bearer {token['access_token']}"
+
         logger.debug(
             "%s request to %s with data: %s and parameters: %s",
             method_upper,
@@ -1250,10 +1251,17 @@ class databrowser:
         ) as error:
             server_msg = ""
             if hasattr(error, 'response') and error.response is not None:
-                error_data = error.response.json()
-                server_msg = (
-                    f" - {error_data.get('detail', error_data.get('message', ''))}"
-                )
+                try:
+                    error_data = error.response.json()
+                    server_msg = (
+                        f" - {error_data.get(
+                            'detail', error_data.get(
+                                'message', error_data.get('error', '')
+                            )
+                        )}"
+                    )
+                except Exception:
+                    pass
             msg = f"{method_upper} request failed with: {error}{server_msg}"
             if self._fail_on_error:
                 raise ValueError(msg) from None

--- a/freva-client/src/freva_client/query.py
+++ b/freva-client/src/freva_client/query.py
@@ -1253,12 +1253,13 @@ class databrowser:
             if hasattr(error, 'response') and error.response is not None:
                 try:
                     error_data = error.response.json()
+                    error_var = {error_data.get(
+                        'detail', error_data.get(
+                            'message', error_data.get('error', '')
+                        )
+                    )}
                     server_msg = (
-                        f" - {error_data.get(
-                            'detail', error_data.get(
-                                'message', error_data.get('error', '')
-                            )
-                        )}"
+                        f" - {error_var}"
                     )
                 except Exception:
                     pass

--- a/freva-client/src/freva_client/utils/auth_utils.py
+++ b/freva-client/src/freva_client/utils/auth_utils.py
@@ -247,7 +247,7 @@ def requires_authentication(
         databrowser_url: Optional[str] = None
 ) -> bool:
     """Check if authentication is required.
-    
+
     Parameters
     ----------
     flavour : str or None

--- a/freva-client/src/freva_client/utils/databrowser_utils.py
+++ b/freva-client/src/freva_client/utils/databrowser_utils.py
@@ -46,9 +46,7 @@ class Config:
         self.auth_url = f"{self.get_api_url(host)}/auth/v2"
         self.get_api_main_url = self.get_api_url(host)
         self.uniq_key = uniq_key
-        self.flavour = flavour or self._get_databrowser_params_from_config().get(
-            "flavour", ""
-        ) or "freva"
+        self.flavour = self.get_flavour(flavour)
 
     @cached_property
     def validate_server(self) -> bool:
@@ -60,6 +58,19 @@ class Config:
             raise ValueError(
                 f"Could not connect to {self.databrowser_url}: {e}"
             ) from None
+
+    def get_flavour(self, flavour: Optional[str]) -> str:
+        """Get the current flavour."""
+        if flavour:
+            return flavour
+        else:
+            try:
+                config_flavour = self._get_databrowser_params_from_config().get(
+                    "flavour", ""
+                )
+                return config_flavour or "freva"
+            except ValueError:
+                return "freva"
 
     def _read_ini(self, path: Path) -> Dict[str, str]:
         """Read an ini file.

--- a/freva-rest/src/freva_rest/cli.py
+++ b/freva-rest/src/freva_rest/cli.py
@@ -44,8 +44,8 @@ environment variables are evaluated:
 - ``API_OIDC_CLIENT_SECRET``: You can set a client secret, if you have
 - ``API_OIDC_TOKEN_CLAIMS``:  Valid token claims, to check against
 - ``API_SERVICES``:  The services the api should serve.
-- ``API_ADMIN_LIST``: List of admin users, that are allowed to add new
-                      global Flavours.
+- ``API_ADMINS_TOKEN_CLAIMS``:  Valid admin token claims, to check if a user
+                                is admin to enable admin endpoints for.
 
 📝  You can override the path to the default config file using the
     ``API_CONFIG`` environment variable. The default location of this config

--- a/freva-rest/src/freva_rest/databrowser_api/endpoints.py
+++ b/freva-rest/src/freva_rest/databrowser_api/endpoints.py
@@ -400,6 +400,7 @@ async def load_data(
         start=start,
         multi_version=multi_version,
         translate=translate,
+        current_user=current_user,
         **SolrSchema.process_parameters(request, "catalogue-type"),
     )
     _, total_count = await solr_search.init_stream()
@@ -512,7 +513,7 @@ async def delete_user_data(
 
 @app.post(
     "/api/freva-nextgen/databrowser/flavours",
-    tags=["Data search"],
+    tags=["Flavour management"],
     status_code=201,
     response_class=JSONResponse,
     responses={
@@ -560,7 +561,7 @@ async def add_custom_flavour(
 
 @app.get(
     "/api/freva-nextgen/databrowser/flavours",
-    tags=["Data search"],
+    tags=["Flavour management"],
     status_code=200,
     response_model=FlavourListResponse,
     responses={
@@ -610,7 +611,7 @@ async def list_flavours(
 
 @app.delete(
     "/api/freva-nextgen/databrowser/flavours/{flavour_name}",
-    tags=["Data search"],
+    tags=["Flavour management"],
     status_code=200,
     response_model=FlavourDeleteResponse,
     responses={

--- a/freva-rest/src/freva_rest/databrowser_api/services/translator.py
+++ b/freva-rest/src/freva_rest/databrowser_api/services/translator.py
@@ -542,7 +542,7 @@ class Flavour:
             message_parts = [
                 (
                     f"Invalid flavour '{original_flavour}'. "
-                    "Available flavours: {all_available}"
+                    f"Available flavours: {all_available}"
                 )
             ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,7 +201,7 @@ def valid_freva_config() -> Iterator[Path]:
             freva_config = Path(temp_dir) / "share" / "freva" / "freva.toml"
             freva_config.parent.mkdir(exist_ok=True, parents=True)
             freva_config.write_text(
-                "[freva]\nhost = 'https://www.freva.com:80/api'"
+                "[freva]\nhost = 'https://www.freva.com:80/api'\ndefault_flavour = 'cmip6'\n"
             )
             yield Path(temp_dir)
 
@@ -219,7 +219,6 @@ def invalid_freva_conf_file() -> Iterator[Path]:
         ):
             freva_config.write_text("[freva]\nhost = https://freva_conf/api")
             yield freva_config
-
 
 @pytest.fixture(scope="function")
 def free_port() -> Iterator[int]:

--- a/tests/test_databrowser_cli.py
+++ b/tests/test_databrowser_cli.py
@@ -487,7 +487,33 @@ def test_flavour_commands(
         assert len(flavours_after) > initial_count
         flavour_names = [f["flavour_name"] for f in flavours_after]
         assert "test_cli_flavour" in flavour_names
-        
+
+        # check the metadata-search with the new personal flavour
+        res = cli_runner.invoke(
+            app,
+            [
+                "metadata-search",
+                "--host", test_server,
+                "--token-file", str(token_file),
+                "--flavour", "test_cli_flavour",
+                "--json"
+            ]
+        )
+        assert res.exit_code == 0
+
+        # check the count with the new personal flavour
+        res = cli_runner.invoke(
+            app,
+            [
+                "data-count",
+                "--host", test_server,
+                "--token-file", str(token_file),
+                "--flavour", "test_cli_flavour",
+                "--json"
+            ]
+        )
+        assert res.exit_code == 0
+
         # deleting the custom flavour
         res = cli_runner.invoke(
             app,

--- a/tests/test_databrowser_py.py
+++ b/tests/test_databrowser_py.py
@@ -446,7 +446,13 @@ def test_flavour_operations(test_server: str, auth_instance: Auth, auth: Token) 
         db = databrowser(flavour="test_flavour_client", host=test_server)
         # not fail even if no results since flavour is custom
         assert len(db) >= 0
-        
+
+        # checking count values with custom flavour
+        db_count = databrowser.count_values(
+            "projekt", flavour="test_flavour_client", host=test_server
+        )
+        assert isinstance(db_count, dict)
+
         # deleting the custom flavour
         databrowser.flavour(
             action="delete",

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -14,16 +14,19 @@ def test_invalid_eval_config(invalid_eval_conf_file: Path) -> None:
     assert invalid_eval_conf_file.is_file()
     with pytest.raises(ValueError):
         databrowser()
-    with pytest.raises(ValueError, match="No databrowser host configured, please use a configuration defining a databrowser host or set a host name using the `host` key"):
-        databrowser(host="www.example.com")
+    db = databrowser(host="www.example.com:8080")
+    assert (
+        db.url == "http://www.example.com:8080/api/freva-nextgen/databrowser"
+    )
+
 
 def test_invalid_freva_config(invalid_freva_conf_file: Path) -> None:
     """Test if loading an invalid freva config file fails."""
     assert invalid_freva_conf_file.is_file()
     with pytest.raises(ValueError):
         databrowser()
-    with pytest.raises(ValueError, match="No databrowser host configured, please use a configuration defining a databrowser host or set a host name using the `host` key"):
-        databrowser(host="www.example.com")
+    db = databrowser(host="https://www.example.com")
+    assert db.url == "https://www.example.com/api/freva-nextgen/databrowser"
 
 
 def test_valid_eval_config(valid_eval_conf_file: Path) -> None:
@@ -65,3 +68,5 @@ def test_valid_freva_config(valid_freva_config: Path) -> None:
             assert db.url == (
                 "https://www.freva.com/api/freva-nextgen/databrowser"
             )
+        # test if custom flavour is read correctly
+        assert db._flavour == "cmip6"

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -14,19 +14,16 @@ def test_invalid_eval_config(invalid_eval_conf_file: Path) -> None:
     assert invalid_eval_conf_file.is_file()
     with pytest.raises(ValueError):
         databrowser()
-    db = databrowser(host="www.example.com:8080")
-    assert (
-        db.url == "http://www.example.com:8080/api/freva-nextgen/databrowser"
-    )
-
+    with pytest.raises(ValueError, match="No databrowser host configured, please use a configuration defining a databrowser host or set a host name using the `host` key"):
+        databrowser(host="www.example.com")
 
 def test_invalid_freva_config(invalid_freva_conf_file: Path) -> None:
     """Test if loading an invalid freva config file fails."""
     assert invalid_freva_conf_file.is_file()
     with pytest.raises(ValueError):
         databrowser()
-    db = databrowser(host="https://www.example.com")
-    assert db.url == "https://www.example.com/api/freva-nextgen/databrowser"
+    with pytest.raises(ValueError, match="No databrowser host configured, please use a configuration defining a databrowser host or set a host name using the `host` key"):
+        databrowser(host="www.example.com")
 
 
 def test_valid_eval_config(valid_eval_conf_file: Path) -> None:


### PR DESCRIPTION
Here, we are going to introduce the default flavour option on the client side config file (adding `default_flavour` in `freva.toml` under the `freva` table; as same as the `host`) and also there were bunch of minor issues that all are fixed as well.