### PR TITLE
fix: config file precedence issue causing malformed host URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+##[v2509.2.0]
+### Changed
+- Fix config file precedence issue causing malformed host URLs in freva-client
+
 ##[v2509.1.0]
 ### Changed
 - Switched to device login flow for python-lib and cli clients.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
 ##[v2509.2.0]
 ### Changed
 - Fix config file precedence issue causing malformed host URLs in freva-client

--- a/freva-client/src/freva_client/__init__.py
+++ b/freva-client/src/freva_client/__init__.py
@@ -18,5 +18,5 @@ official documentation: https://freva-org.github.io/freva-legacy
 from .auth import authenticate
 from .query import databrowser
 
-__version__ = "2509.1.0"
+__version__ = "2509.2.0"
 __all__ = ["authenticate", "databrowser", "__version__"]

--- a/freva-client/src/freva_client/utils/databrowser_utils.py
+++ b/freva-client/src/freva_client/utils/databrowser_utils.py
@@ -188,30 +188,34 @@ class Config:
 
     def _get_databrowser_params_from_config(self) -> Dict[str, str]:
         """Get the config file order."""
-
         eval_conf = self.get_dirs(user=False) / "evaluation_system.conf"
         freva_config = Path(
             os.environ.get("FREVA_CONFIG")
             or Path(self.get_dirs(user=False)) / "freva.toml"
         )
         paths: Dict[Path, Literal["toml", "ini"]] = {
-            Path(appdirs.user_config_dir("freva")) / "freva.toml": "toml",
-            Path(self.get_dirs(user=True)) / "freva.toml": "toml",
-            freva_config: "toml",
             Path(
                 os.environ.get("EVALUATION_SYSTEM_CONFIG_FILE") or eval_conf
             ): "ini",
+            Path(appdirs.user_config_dir("freva")) / "freva.toml": "toml",
+            Path(self.get_dirs(user=True)) / "freva.toml": "toml",
+            freva_config: "toml",
         }
+
+        result_host = ""
+        result_flavour = ""
+
         for config_path, config_type in paths.items():
             if config_path.is_file():
                 config_data = self._read_config(config_path, config_type)
-                host = config_data.get("host", "")
-                flavour = config_data.get("flavour", "")
-                if host:
-                    return {
-                        "host": host,
-                        "flavour": flavour
-                    }
+                if not result_host and config_data.get("host", ""):
+                    result_host = config_data["host"]
+                if not result_flavour and config_data.get("flavour", ""):
+                    result_flavour = config_data["flavour"]
+
+        if result_host:
+            return {"host": result_host, "flavour": result_flavour}
+
         raise ValueError(
             "No databrowser host configured, please use a"
             " configuration defining a databrowser host or"


### PR DESCRIPTION
When we were adding default_flavour support in client, the config reading logic incorrectly prioritized TOML files over INI files. This caused the system to use empty/invalid host values from default TOML configs (`host = "http://"`) instead of valid hosts from user INI configs (`databrowser.host = "https://actual-server.com"`).

The fix changes the config reading to collect host and flavour separately from multiple files, ensuring `Host` values come from INI files first (preserving existing user configs), and `Flavour` values can still be read from TOML files.

@antarcticrainforest could you please take a look at this. It needs to be released as well, since we need to update the pypi and conda versions. Shall i change the `freva-rest` version to 2509.2.0 as well?
