### PR TITLE
Add HTML format support to .zmetadata endpoint

### DIFF
--- a/tests/test_load_zarr.py
+++ b/tests/test_load_zarr.py
@@ -54,6 +54,7 @@ def test_load_files_success(test_server: str, auth: Dict[str, str]) -> None:
     files = list(res2.iter_lines(decode_unicode=True))
     assert len(files) == 2
     time.sleep(4)
+    # zarr metadata json
     data = requests.get(
         f"{files[0]}/.zmetadata",
         headers={"Authorization": f"Bearer {token}"},
@@ -61,6 +62,14 @@ def test_load_files_success(test_server: str, auth: Dict[str, str]) -> None:
     )
     assert data.status_code == 200
     assert "metadata" in data.json()
+    # zarr metadata xarray-html-formatted
+    data = requests.get(
+        f"{files[0]}/.zmetadata?format=html",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=3,
+    )
+    assert data.status_code == 200
+    assert "<div><" in data.text
     data = requests.get(
         f"{files[0]}/.zgroup",
         headers={"Authorization": f"Bearer {token}"},


### PR DESCRIPTION
This PR adds a `format` parameter to the `.zmetadata` endpoint, allowing it to return either JSON (default) or Xarray's native HTML format.

Now that the web client can authenticate directly with freva-rest, we want to replace the metadata inspector functionality with zarr streaming. This requires displaying dataset metadata in the same HTML format that Xarray produces.
In the beginning we considered generating the HTML layout web-client-side from the JSON response, but this has drawbacks:
1. Any style changes in Xarray would require manual updates to maintain identical output
2. Reimplementing Xarray's HTML rendering would significantly increase client codebase complexity

By serving Xarray's HTML directly from the backend, we avoid duplicating styling logic and automatically stay in sync with Xarray's representation.